### PR TITLE
не обращаться к $KCODE если руби 1.9

### DIFF
--- a/lib/gilenson.rb
+++ b/lib/gilenson.rb
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8 -*-
-old_kcode = $KCODE
-$KCODE = 'u' if RUBY_VERSION < '1.9.0'
+if RUBY_VERSION < '1.9.0'
+  old_kcode = $KCODE
+  $KCODE = 'u'
+end
 
 class Gilenson
   VERSION = '1.2.1'


### PR DESCRIPTION
при испольовании gilenson под ruby 1.9.2 выдаётся предупреждение:
    lib/gilenson.rb:2: warning: variable $KCODE is no longer effective  
